### PR TITLE
typechain and typechain/ethers-v5 should be on dependencies instead o…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "author": "Rodrigo Herrera I",
     "license": "LGPL-3.0",
     "dependencies": {
-        "ethers": "^5.6.9"
+        "ethers": "^5.6.9",
+        "@typechain/ethers-v5": "^10.1.0",
+        "typechain": "^8.1.0"
     },
     "devDependencies": {
         "@changesets/cli": "^2.23.0",
-        "@typechain/ethers-v5": "^10.1.0",
         "@types/chai": "^4.3.1",
         "@types/mocha": "^9.1.1",
         "chai": "^4.3.6",
@@ -26,7 +27,6 @@
         "mocha": "^10.0.0",
         "prettier": "^2.6.2",
         "ts-mocha": "^10.0.0",
-        "typechain": "^8.1.0",
         "typescript": "^4.6.4"
     }
 }


### PR DESCRIPTION
These packages should be on dependencies, so we don't need to install them previous to usage when installing the sdk through npm.